### PR TITLE
fix uninitialized property check before being accessed

### DIFF
--- a/src/Health/HealthCheckDefinition.php
+++ b/src/Health/HealthCheckDefinition.php
@@ -123,12 +123,12 @@ class HealthCheckDefinition extends AbstractModel implements \JsonSerializable
         } else {
             $this->Interval = ReadableDuration::fromDuration((string)$this->IntervalDuration);
         }
-        if (null === $this->TimeoutDuration) {
+        if (!isset($this->TimeoutDuration)) {
             $this->TimeoutDuration = Time::ParseDuration((string)$this->Timeout);
         } else {
             $this->Timeout = ReadableDuration::fromDuration((string)$this->TimeoutDuration);
         }
-        if (null === $this->DeregisterCriticalServiceAfterDuration) {
+        if (!isset($this->DeregisterCriticalServiceAfterDuration)) {
             $this->DeregisterCriticalServiceAfterDuration = Time::ParseDuration(
                 (string)$this->DeregisterCriticalServiceAfter
             );


### PR DESCRIPTION
In PHP 7.4 accessing uninitialized property throws exception

eg. HealthCheckDefinition::$TimeoutDuration must not be accessed before initialization