### PR TITLE
Dev : PHP Deprecated problem caused by modifying FakeMap.php.

### DIFF
--- a/src/FakeMap.php
+++ b/src/FakeMap.php
@@ -60,6 +60,7 @@ class FakeMap implements \ArrayAccess, \Countable, \Iterator, \JsonSerializable
         );
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @return mixed
      */
@@ -73,6 +74,7 @@ class FakeMap implements \ArrayAccess, \Countable, \Iterator, \JsonSerializable
         next($this->_map);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @return bool|float|int|string|null
      */
@@ -103,6 +105,7 @@ class FakeMap implements \ArrayAccess, \Countable, \Iterator, \JsonSerializable
         return isset($this->_map[$offset]) || \array_key_exists($offset, $this->_map);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @param mixed $offset
      * @return mixed


### PR DESCRIPTION
**Description**
see #41 



**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide
