### PR TITLE
Fix issue with dynamic array fields in PHP 8.2

### DIFF
--- a/src/AbstractModel.php
+++ b/src/AbstractModel.php
@@ -60,9 +60,12 @@ abstract class AbstractModel implements \JsonSerializable
         $this->_dyn[$field] = $value;
     }
 
-    public function __get(string $field)
+    public function &__get(string $field)
     {
-        return $this->_dyn[$field] ?? null;
+        if (!array_key_exists($field, $this->_dyn)) {
+            $this->_dyn[$field] = null;
+        }
+        return $this->_dyn[$field];
     }
 
     /**

--- a/tests/Usage/Agent/AgentServiceConnectProxyConfigTest.php
+++ b/tests/Usage/Agent/AgentServiceConnectProxyConfigTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DCarbone\PHPConsulAPITests\Usage\Agent;
+
+use DCarbone\PHPConsulAPI\Agent\AgentServiceConnectProxyConfig;
+use DCarbone\PHPConsulAPITests\Usage\AbstractUsageTests;
+
+/**
+ * @copyright ResearchGate GmbH
+ */
+class AgentServiceConnectProxyConfigTest extends AbstractUsageTests
+{
+    public function test_construct_givenConfig_willUnmarshalConfigValuesSuccessfully()
+    {
+        $config = new AgentServiceConnectProxyConfig([
+            'Config' => [
+                'envoy_prometheus_bind_addr' => "0.0.0.0:12345",
+                'handshake_timeout_ms' => 10000,
+                'local_connect_timeout_ms' => 1000,
+                'local_request_timeout_ms' => 0,
+                'protocol' => "http",
+            ],
+        ]);
+
+        $this->assertSame([
+            'envoy_prometheus_bind_addr' => "0.0.0.0:12345",
+            'handshake_timeout_ms' => 10000,
+            'local_connect_timeout_ms' => 1000,
+            'local_request_timeout_ms' => 0,
+            'protocol' => "http",
+        ], $config->Config);
+    }
+}


### PR DESCRIPTION
Would issue "Indirect modification of overloaded property has no effect" in Unmarshaller.php:353 and not set the value otherwise.

The problem is that
```
$this->{$field}[$k] = $this->buildScalarValue($field, $v, $type, false);
```
will first call `AbstractModel::__get($field)` and then `AbstractModel::__set($field)` with `[$k]` modified and not `AbstractModel::__set($field[$k])` immediately.
Because `__get(()` didn't return a reference, the `__set()` didn't have an actual effect.

I went with return the value from `__get()` via reference, because it needed only a few lines of changes.

Another option would have been to build up the array (call it e.g. `$unmarshalledArray`) for `$field` in `unmarshalArray()` and issue one `$this->{$field} = $unmarshalledArray;`. This would bypass `__get()` and immediately call `__set()`, avoiding the issue as well.